### PR TITLE
[Storage] Use new QueueMessage APIs instead of deprecated.

### DIFF
--- a/queues/howto/dotnet/dotnet-v12/QueueBasics.cs
+++ b/queues/howto/dotnet/dotnet-v12/QueueBasics.cs
@@ -120,7 +120,7 @@ namespace dotnet_v12
                 PeekedMessage[] peekedMessage = queueClient.PeekMessages();
 
                 // Display the message
-                Console.WriteLine($"Peeked message: '{peekedMessage[0].MessageText}'");
+                Console.WriteLine($"Peeked message: '{peekedMessage[0].Body}'");
             }
         }
         // </snippet_PeekMessage>
@@ -170,7 +170,7 @@ namespace dotnet_v12
                 QueueMessage[] retrievedMessage = queueClient.ReceiveMessages();
 
                 // Process (i.e. print) the message in less than 30 seconds
-                Console.WriteLine($"Dequeued message: '{retrievedMessage[0].MessageText}'");
+                Console.WriteLine($"Dequeued message: '{retrievedMessage[0].Body}'");
 
                 // Delete the message
                 queueClient.DeleteMessage(retrievedMessage[0].MessageId, retrievedMessage[0].PopReceipt);
@@ -223,7 +223,7 @@ namespace dotnet_v12
                 foreach (QueueMessage message in receivedMessages)
                 {
                     // Process (i.e. print) the messages in less than 5 minutes
-                    Console.WriteLine($"De-queued message: '{message.MessageText}'");
+                    Console.WriteLine($"De-queued message: '{message.Body}'");
 
                     // Delete the message
                     queueClient.DeleteMessage(message.MessageId, message.PopReceipt);
@@ -284,11 +284,11 @@ namespace dotnet_v12
 
             // Async receive the message
             QueueMessage[] retrievedMessage = await queueClient.ReceiveMessagesAsync();
-            Console.WriteLine($"Retrieved message with content '{retrievedMessage[0].MessageText}'");
+            Console.WriteLine($"Retrieved message with content '{retrievedMessage[0].Body}'");
 
             // Async delete the message
             await queueClient.DeleteMessageAsync(retrievedMessage[0].MessageId, retrievedMessage[0].PopReceipt);
-            Console.WriteLine($"Deleted message: '{retrievedMessage[0].MessageText}'");
+            Console.WriteLine($"Deleted message: '{retrievedMessage[0].Body}'");
 
             // Async delete the queue
             await queueClient.DeleteAsync();

--- a/queues/howto/dotnet/dotnet-v12/dotnet-v12.csproj
+++ b/queues/howto/dotnet/dotnet-v12/dotnet-v12.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.3.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.6.2" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 

--- a/queues/tutorial/dotnet/dotnet-v12/QueueApp/Initial.cs
+++ b/queues/tutorial/dotnet/dotnet-v12/QueueApp/Initial.cs
@@ -40,7 +40,7 @@ namespace QueueApp
                 if (properties.ApproximateMessagesCount > 0)
                 {
                     QueueMessage[] retrievedMessage = await theQueue.ReceiveMessagesAsync(1);
-                    string theMessage = retrievedMessage[0].MessageText;
+                    string theMessage = retrievedMessage[0].Body.ToString();
                     await theQueue.DeleteMessageAsync(retrievedMessage[0].MessageId, retrievedMessage[0].PopReceipt);
                     return theMessage;
                 }

--- a/queues/tutorial/dotnet/dotnet-v12/QueueApp/Program.cs
+++ b/queues/tutorial/dotnet/dotnet-v12/QueueApp/Program.cs
@@ -76,7 +76,7 @@ namespace QueueApp
                 if (properties.ApproximateMessagesCount > 0)
                 {
                     QueueMessage[] retrievedMessage = await theQueue.ReceiveMessagesAsync(1);
-                    string theMessage = retrievedMessage[0].MessageText;
+                    string theMessage = retrievedMessage[0].Body.ToString();
                     await theQueue.DeleteMessageAsync(retrievedMessage[0].MessageId, retrievedMessage[0].PopReceipt);
                     return theMessage;
                 }

--- a/queues/tutorial/dotnet/dotnet-v12/QueueApp/QueueApp.csproj
+++ b/queues/tutorial/dotnet/dotnet-v12/QueueApp/QueueApp.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Queues" Version="12.3.2" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.6.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This is to address https://github.com/Azure/azure-sdk-for-net/issues/23011 .
The `QueueMessage.MessageText` has been deprecated and replaced with `QueueMessage.Body` .

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
