### PR TITLE
Update .NET ADLS samples

### DIFF
--- a/blobs/howto/dotnet/dotnet-v12/ACL_DataLake.cs
+++ b/blobs/howto/dotnet/dotnet-v12/ACL_DataLake.cs
@@ -362,11 +362,13 @@ namespace dotnet_v12
             Console.WriteLine("X) Exit to main menu");
             Console.Write("\r\nSelect an option: ");
 
-            Authorize_DataLake.GetDataLakeServiceClient(ref dataLakeServiceClient, Constants.storageAccountName, Constants.accountKey);
+            // Uncomment if you want to test shared key auth.
+            DataLakeServiceClient dataLakeServiceClient = 
+                Authorize_DataLake.GetDataLakeServiceClient(Constants.storageAccountName, Constants.accountKey);
 
-            // Uncomment if you want to test AD Authorization.
-            //   Authorize_DataLake.GetDataLakeServiceClient(ref dataLakeServiceClient, Constants.storageAccountName, 
-            //       Constants.clientID, Constants.clientSecret, Constants.tenantID);
+            // Uncomment if you want to test AAD auth.
+            //DataLakeServiceClient dataLakeServiceClient = 
+            //    Authorize_DataLake.GetDataLakeServiceClient(Constants.storageAccountName);
 
             // Get file system client
 

--- a/blobs/howto/dotnet/dotnet-v12/Authorize_DataLake.cs
+++ b/blobs/howto/dotnet/dotnet-v12/Authorize_DataLake.cs
@@ -42,5 +42,16 @@ namespace dotnet_v12
                                     new DefaultAzureCredential());
         }
         // </Snippet_AuthorizeWithAAD>
+
+        // <Snippet_AuthorizeWithSAS>
+        public static void GetDataLakeServiceClientSAS(ref DataLakeServiceClient dataLakeServiceClient,
+            String accountName, String sasToken)
+        {
+            string dfsUri = "https://" + accountName + ".dfs.core.windows.net";
+
+            dataLakeServiceClient = new DataLakeServiceClient(
+                new Uri($"{dfsUri}?{sasToken}"));
+         }
+        // </Snippet_AuthorizeWithSAS>
     }
 }

--- a/blobs/howto/dotnet/dotnet-v12/Authorize_DataLake.cs
+++ b/blobs/howto/dotnet/dotnet-v12/Authorize_DataLake.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Core;
+﻿using Azure;
+using Azure.Core;
 using Azure.Identity;
 using Azure.Storage;
 using Azure.Storage.Files.DataLake;
@@ -49,9 +50,9 @@ namespace dotnet_v12
         {
             string dfsUri = "https://" + accountName + ".dfs.core.windows.net";
 
-            dataLakeServiceClient = new DataLakeServiceClient(
-                new Uri($"{dfsUri}?{sasToken}"));
-         }
+            dataLakeServiceClient = new DataLakeServiceClient(new Uri(dfsUri), 
+                                    new AzureSasCredential(sasToken));
+        }
         // </Snippet_AuthorizeWithSAS>
     }
 }

--- a/blobs/howto/dotnet/dotnet-v12/Authorize_DataLake.cs
+++ b/blobs/howto/dotnet/dotnet-v12/Authorize_DataLake.cs
@@ -16,16 +16,17 @@ namespace dotnet_v12
         //----------------------------------------------------------
 
         // <Snippet_AuthorizeWithKey>
-        public static void GetDataLakeServiceClient(ref DataLakeServiceClient dataLakeServiceClient,
-            string accountName, string accountKey)
+        public static DataLakeServiceClient GetDataLakeServiceClient(string accountName, string accountKey)
         {
             StorageSharedKeyCredential sharedKeyCredential =
                 new StorageSharedKeyCredential(accountName, accountKey);
 
-            string dfsUri = "https://" + accountName + ".dfs.core.windows.net";
+            string dfsUri = $"https://{accountName}.dfs.core.windows.net";
 
-            dataLakeServiceClient = new DataLakeServiceClient
+            DataLakeServiceClient dataLakeServiceClient = new DataLakeServiceClient
                 (new Uri(dfsUri), sharedKeyCredential);
+
+            return dataLakeServiceClient;
         }
         // </Snippet_AuthorizeWithKey>
 
@@ -34,24 +35,26 @@ namespace dotnet_v12
         //----------------------------------------------------------
 
         // <Snippet_AuthorizeWithAAD>
-        public static void GetDataLakeServiceClient(ref DataLakeServiceClient dataLakeServiceClient,
-            String accountName)
+        public static DataLakeServiceClient GetDataLakeServiceClient(string accountName)
         {
-            string dfsUri = "https://" + accountName + ".dfs.core.windows.net";
+            string dfsUri = $"https://{accountName}.dfs.core.windows.net";
 
-            dataLakeServiceClient = new DataLakeServiceClient(new Uri(dfsUri), 
+            DataLakeServiceClient dataLakeServiceClient = new DataLakeServiceClient(new Uri(dfsUri), 
                                     new DefaultAzureCredential());
+
+            return dataLakeServiceClient;
         }
         // </Snippet_AuthorizeWithAAD>
 
         // <Snippet_AuthorizeWithSAS>
-        public static void GetDataLakeServiceClientSAS(ref DataLakeServiceClient dataLakeServiceClient,
-            String accountName, String sasToken)
+        public static DataLakeServiceClient GetDataLakeServiceClientSAS(string accountName, string sasToken)
         {
-            string dfsUri = "https://" + accountName + ".dfs.core.windows.net";
+            string dfsUri = $"https://{accountName}.dfs.core.windows.net";
 
-            dataLakeServiceClient = new DataLakeServiceClient(new Uri(dfsUri), 
+            DataLakeServiceClient dataLakeServiceClient = new DataLakeServiceClient(new Uri(dfsUri), 
                                     new AzureSasCredential(sasToken));
+
+            return dataLakeServiceClient;
         }
         // </Snippet_AuthorizeWithSAS>
     }

--- a/blobs/howto/dotnet/dotnet-v12/CRUD_DataLake.cs
+++ b/blobs/howto/dotnet/dotnet-v12/CRUD_DataLake.cs
@@ -398,7 +398,7 @@ namespace dotnet_v12
             Console.Write("\r\nSelect an option: ");
 
             // Uncomment to test SAS authorization
-            //Authorize_DataLake.GetDataLakeServiceClientSAS(ref dataLakeServiceClient, Constants.storageAccountName, "<sas-token");
+            //Authorize_DataLake.GetDataLakeServiceClientSAS(ref dataLakeServiceClient, Constants.storageAccountName, "<sas-token>");
 
             // Uncomment to test shared key authorization
             Authorize_DataLake.GetDataLakeServiceClient(ref dataLakeServiceClient, Constants.storageAccountName, Constants.accountKey);
@@ -419,8 +419,8 @@ namespace dotnet_v12
             string subdirectoryNameNew = "renamed-sample-directory";
             string fileName = "testfile.txt";
 
-            string localPath = @"C:\Users\pauljewell\OneDrive - Microsoft\Desktop\Blob\testfile.txt";
-            string localPathAppend = @"C:\Users\pauljewell\OneDrive - Microsoft\Desktop\Blob\appendfile.txt";
+            string localPath = @"<local-path>";
+            string localPathAppend = @"<local-path-for-append>";
 
             switch (Console.ReadLine())
             {


### PR DESCRIPTION
Refresh pass on .NET ADLS how-to. Main change is to update the samples to position `DataLakeFileClient.UploadAsync` as the recommendation for uploading a file, and `DataLakeFileClient.AppendAsync` / `FlushAsync` as the choice for actually appending data to an existing file. This will be reflected in the [main article](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-directory-file-acl-dotnet#upload-a-file-to-a-directory) once the samples are updated here.

@jaschrep-msft If you have a chance, could you take a quick look at the Upload and Append methods in the sample and make sure these scenarios align with intended usage? Much appreciated.