### PR TITLE
Update blob-delete.ts

### DIFF
--- a/blobs/howto/TypeScript/NodeJS-v12/dev-guide/src/blob-delete.ts
+++ b/blobs/howto/TypeScript/NodeJS-v12/dev-guide/src/blob-delete.ts
@@ -26,7 +26,7 @@ async function deleteBlob(
 ): Promise<void> {
   // Create blob client from container client
   const blockBlobClient: BlockBlobClient =
-    await containerClient.getBlockBlobClient(blobName);
+    containerClient.getBlockBlobClient(blobName);
 
   // include: Delete the base blob and all of its snapshots.
   // only: Delete only the blob's snapshots and not the blob itself.
@@ -48,7 +48,8 @@ async function deleteBlobIfItExists(
   blobName
 ): Promise<void> {
   // Create blob client from container client
-  const blockBlobClient = await containerClient.getBlockBlobClient(blobName);
+  const blockBlobClient: BlockBlobClient =
+    containerClient.getBlockBlobClient(blobName);
 
   // include: Delete the base blob and all of its snapshots.
   // only: Delete only the blob's snapshots and not the blob itself.
@@ -70,7 +71,7 @@ async function undeleteBlob(
 ): Promise<void> {
   // Create blob client from container client
   const blockBlobClient: BlockBlobClient =
-    await containerClient.getBlockBlobClient(blobName);
+    containerClient.getBlockBlobClient(blobName);
 
   const options: BlobUndeleteOptions = {};
   const blobUndeleteResponse: BlobUndeleteResponse =
@@ -92,9 +93,8 @@ async function createBlobFromString(
   uploadOptions: BlockBlobUploadOptions
 ): Promise<void> {
   // Create blob client from container client
-  const blockBlobClient: BlockBlobClient = await client.getBlockBlobClient(
-    blobName
-  );
+  const blockBlobClient: BlockBlobClient = 
+    client.getBlockBlobClient(blobName);
 
   console.log(`uploading blob ${blobName}`);
 


### PR DESCRIPTION
Removed `await` because .getBlockBlobClient() doesn't return a promise.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
I was using this code in my codebase and I got linting errors. Apparently in other parts of the code, no await is use e.g. the npm docs.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->